### PR TITLE
Refactor configuration usage and clean backend code

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,15 +112,12 @@ This is in a testing environment. If pushed to the app store, additional costs w
     ```
 
 3. **Configure API Connection**:
-    - Open the file `api.js` in a text editor
-    - Find this section (around line 23):
-      ```javascript
-      // For mobile (iOS/Android)
-      // Use your local network IP address instead of localhost
-      return 'http://172.30.1.54:8000/api';  // Update this IP address
+    - Set the environment variable `EXPO_PUBLIC_API_URL` to your backend's URL.
+      For example:
+      ```bash
+      export EXPO_PUBLIC_API_URL="http://YOUR_IP_ADDRESS:8000/api"
       ```
-    - Replace the IP address with your computer's IP address (that you noted in step 7 of Backend Setup)
-    - Save the file
+    - This avoids editing `api.js` directly and works for both web and mobile builds.
 
 4. **Start the App**:
     ```bash
@@ -141,7 +138,7 @@ This is in a testing environment. If pushed to the app store, additional costs w
 
 1. **Network Error When Logging In**:
    - If you get an "ERR_NETWORK" or "Network Error" message when trying to log in:
-   - Double check that you've updated the IP address in `api.js` to match your computer's current IP
+   - Ensure the `EXPO_PUBLIC_API_URL` environment variable points to your current IP address
    - Verify this by looking at the output of the backend server startup
    - This is especially important if you switch networks or restart your computer, as the IP may change
 
@@ -149,7 +146,7 @@ This is in a testing environment. If pushed to the app store, additional costs w
    - On Windows: Open Command Prompt and type `ipconfig`
    - On macOS/Linux: Open Terminal and type `ifconfig` or `ip addr`
    - Look for the IPv4 address of your WiFi or Ethernet connection
-   - Update the `api.js` file with this IP address
+   - Update the `EXPO_PUBLIC_API_URL` variable with this IP address
 
 3. **Different Networks**:
    - Your phone and computer MUST be on the same network for the connection to work

--- a/backend/coreViews/utils.py
+++ b/backend/coreViews/utils.py
@@ -1,0 +1,6 @@
+from django.contrib.auth.models import User
+
+
+def get_default_user():
+    """Return the default user for anonymous actions."""
+    return User.objects.get(username="default_user")

--- a/backend/coreViews/views.py
+++ b/backend/coreViews/views.py
@@ -8,6 +8,7 @@ from rest_framework.authtoken.views import ObtainAuthToken
 from django.contrib.auth import authenticate
 
 from .models import Patient, Scan, AIModel, UserProfile
+from .utils import get_default_user
 from .serializers import PatientSerializer, ScanSerializer, AIModelSerializer
 from django.contrib.auth.models import User
 
@@ -96,10 +97,8 @@ class PatientViewSet(viewsets.ModelViewSet):
 
     def perform_create(self, serializer):
         if self.request.user.is_anonymous:
-            # Useing default user
-            # Default user 'default_user' created with password 'default_password'.
-            default_user = User.objects.get(username="default_user") 
-            serializer.save(user=default_user)
+            # Assign to a default user when unauthenticated
+            serializer.save(user=get_default_user())
         else:
             serializer.save(user=self.request.user)
 
@@ -124,10 +123,8 @@ class ScanViewSet(viewsets.ModelViewSet):
     
     def perform_create(self, serializer):
         if self.request.user.is_anonymous:
-            # Using default user
-            # Default user 'default_user' created with password 'default_password'.
-            default_user = User.objects.get(username="default_user") 
-            serializer.save(user=default_user)
+            # Assign to a default user when unauthenticated
+            serializer.save(user=get_default_user())
         else:
             serializer.save(user=self.request.user)
     

--- a/frontend/api.js
+++ b/frontend/api.js
@@ -3,7 +3,14 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Platform } from 'react-native';
 
 // Determine the base URL based on the environment
+// Allows overriding via EXPO_PUBLIC_API_URL (Expo) or API_URL (web) environment variables
 const getBaseUrl = () => {
+  // Environment variable override
+  const envUrl = process.env.EXPO_PUBLIC_API_URL || process.env.API_URL;
+  if (envUrl) {
+    return envUrl;
+  }
+
   // For web browser
   if (Platform.OS === 'web') {
     // Make sure window and location are defined


### PR DESCRIPTION
## Summary
- add utility helper for retrieving default user
- refactor PatientViewSet and ScanViewSet to use helper
- support API URL override via environment variable
- update docs to use new EXPO_PUBLIC_API_URL variable

## Testing
- `python -m compileall backend`

------
https://chatgpt.com/codex/tasks/task_e_685710879838832c953f5bda69d93d10